### PR TITLE
Permit login to Docker.io for additional pull requests.

### DIFF
--- a/hauler_all_the_things.sh
+++ b/hauler_all_the_things.sh
@@ -14,7 +14,7 @@ set -ebpf
 
 # application domain name
 export DOMAIN=awesome.sauce
-export LOGIN=''
+export LOGIN=''  # Set to your docker.io ID to enable login and account usage capacity.
 
 ######  NO MOAR EDITS #######
 # color

--- a/hauler_all_the_things.sh
+++ b/hauler_all_the_things.sh
@@ -14,7 +14,7 @@ set -ebpf
 
 # application domain name
 export DOMAIN=awesome.sauce
-
+export LOGIN=''
 
 ######  NO MOAR EDITS #######
 # color
@@ -79,6 +79,14 @@ function build () {
   info_ok
 
   cd /opt/hauler
+
+  # Permit user to use Docker login to the repositories to bypass login limits if imposed.
+  if [ ! -z "${LOGIN}" ] ; then
+    LOGIN_PW=""
+    read -sp "Need login to docker.com for \"${LOGIN}\": " LOGIN_PW
+    /usr/local/bin/hauler login docker.io -u ${LOGIN} -p "${LOGIN_PW}"
+    unset LOGIN_PW
+  fi
 
   info "creating hauler manifest"
   # versions


### PR DESCRIPTION
This code will permit a user to use credentials for Docker.io for additional pull requests per day.

While playing with this script I hit the Docker.io limit and added this as a quick workaround.