### PR TITLE
Make temporary file location a variable.

### DIFF
--- a/hauler_all_the_things.sh
+++ b/hauler_all_the_things.sh
@@ -14,7 +14,7 @@ set -ebpf
 
 # application domain name
 export DOMAIN=awesome.sauce
-export LOGIN=''
+export LOGIN=''  # Set to your docker.io ID to enable login and account usage capacity.
 
 ######  NO MOAR EDITS #######
 # color

--- a/hauler_all_the_things.sh
+++ b/hauler_all_the_things.sh
@@ -16,7 +16,6 @@ set -ebpf
 export DOMAIN=awesome.sauce
 
 export TMPDIR=/var/tmp
-export LOGIN='' # Only set if you need to login to the source container repository.
 
 ######  NO MOAR EDITS #######
 # color

--- a/hauler_all_the_things.sh
+++ b/hauler_all_the_things.sh
@@ -14,7 +14,7 @@ set -ebpf
 
 # application domain name
 export DOMAIN=awesome.sauce
-
+export LOGIN=''
 
 ######  NO MOAR EDITS #######
 # color
@@ -79,6 +79,14 @@ function build () {
   info_ok
 
   cd /opt/hauler
+
+  # Permit user to use Docker login to the repositories to bypass login limits if imposed.
+  if [ ! -z "${LOGIN}" ] ; then
+    LOGIN_PW=""
+    read -sp "Need login to docker.com for \"${LOGIN}\": " LOGIN_PW
+    /usr/local/bin/hauler login docker.io -u ${LOGIN} -p "${LOGIN_PW}"
+    unset LOGIN_PW
+  fi
 
   info "creating hauler manifest"
   # versions

--- a/hauler_all_the_things.sh
+++ b/hauler_all_the_things.sh
@@ -14,6 +14,7 @@ set -ebpf
 
 # application domain name
 export DOMAIN=awesome.sauce
+export LOGIN='' # Set to your docker.io ID to enable login and account usage capacity.
 export TMPDIR=/var/tmp
 
 ######  NO MOAR EDITS #######


### PR DESCRIPTION
This removes the need for "/opt/" to be writable by a users and permits the script to be run by non-root users.

I took the liberty of updating the comment lines so future work to re-activate them should work as well.